### PR TITLE
Update steer_bot config yaml for new steer_drive configulation.

### DIFF
--- a/cirkit_unit03_gazebo/config/cirkit_unit03_hardware_gazebo.yaml
+++ b/cirkit_unit03_gazebo/config/cirkit_unit03_hardware_gazebo.yaml
@@ -1,0 +1,11 @@
+steer_bot_hardware_gazebo:
+    rear_wheel  : 'rear_wheel_joint'
+    front_steer : 'front_steer_joint'
+    virtual_rear_wheels  : ['base_to_right_rear_wheel', 'base_to_left_rear_wheel']
+    virtual_front_wheels : ['base_to_right_front_wheel', 'base_to_left_front_wheel']
+    virtual_front_steers : ['base_to_right_front_steer', 'base_to_left_front_steer']
+
+    # ackermann link mechanism
+    enable_ackermann_link: true
+    wheel_separation_w : 0.5
+    wheel_separation_h : 0.79

--- a/cirkit_unit03_gazebo/config/pids.yaml
+++ b/cirkit_unit03_gazebo/config/pids.yaml
@@ -1,0 +1,4 @@
+gains:
+  base_to_right_rear_wheel  :  {p: 100000.0, d: 10.0, i: 0.50, i_clamp: 3.0}
+  base_to_left_rear_wheel   :  {p: 100000.0, d: 10.0, i: 0.50, i_clamp: 3.0}
+

--- a/cirkit_unit03_gazebo/launch/cirkit_unit03_clearpath_playpen.launch
+++ b/cirkit_unit03_gazebo/launch/cirkit_unit03_clearpath_playpen.launch
@@ -23,8 +23,8 @@
   <include file="$(find cirkit_unit03_description)/launch/description.launch"/>
 
   <!-- Run a python script to the send a service call to gazebo_ros to spawn a URDF robot -->
-  <rosparam file="$(find steer_bot_hardware_gazebo)/config/joints.yaml" command="load"/>
-  <rosparam file="$(find steer_bot_hardware_gazebo)/config/pids.yaml" command="load"/>
+  <rosparam file="$(find cirkit_unit03_gazebo)/config/cirkit_unit03_hardware_gazebo.yaml" command="load"/>
+  <rosparam file="$(find cirkit_unit03_gazebo)/config/pids.yaml" command="load"/>
 
   <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen"
 	args="-urdf -model cirkit_unit03 -param robot_description -x -0.4 -y -8.00 -z 1"/>


### PR DESCRIPTION
https://github.com/CIR-KIT/steer_drive_ros/issues/11 の対応です．

https://github.com/CIR-KIT/steer_drive_ros/pull/13 と連動です．

- `steer_bot_hardware_gazebo` 設定用のyamlファイルを，`cirkit_unit03_gazebo`に設置．
  * 設定パラメータの内容は，cirkit_unit03 固有の値であるため．