### PR TITLE
Fix dependency

### DIFF
--- a/cirkit_unit03_gazebo/package.xml
+++ b/cirkit_unit03_gazebo/package.xml
@@ -18,6 +18,5 @@
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>roslaunch</exec_depend>
   <exec_depend>rviz</exec_depend>
-  <exec_depend>steer_bot_hardware_gazebo</exec_depend>
   <exec_depend>xacro</exec_depend>
 </package>

--- a/cirkit_unit03_gazebo/package.xml
+++ b/cirkit_unit03_gazebo/package.xml
@@ -16,6 +16,7 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>roslaunch</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>steer_bot_hardware_gazebo</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/cirkit_unit03_gazebo/package.xml
+++ b/cirkit_unit03_gazebo/package.xml
@@ -13,7 +13,6 @@
   <author email="cirkit.infomation@gmail.com">CIR-KIT</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <exec_depend>cirkit_unit03_description</exec_depend>
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>


### PR DESCRIPTION
今ROS Wiki でのドキュメント化を進めているのですが，Jenkinsさんが厳格で怒られます :cry: 

下記関連で叱られるので，package.xmlを修正します．

- apt で取得できないpkgがdependに入っていると怒られる
- おそらく，roslaunch を明示的にdependに追加していないと怒られる．多分いままでうまくいっていたのは，別のパッケージ経由で入っていたからと思われる．